### PR TITLE
URL Cleanup

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,8 +55,8 @@ sourceSets.test.resources.srcDirs = ["src/test/resources", "src/test/java"]
 repositories {
   mavenCentral()
   mavenLocal()
-  maven { url "http://repo.springsource.org/libs-milestone" }
-  maven { url "http://m2.neo4j.org/releases" }
+  maven { url "https://repo.springsource.org/libs-milestone" }
+  maven { url "https://m2.neo4j.org/releases" }
 }
 
 dependencies {

--- a/gradle/maven.gradle
+++ b/gradle/maven.gradle
@@ -31,20 +31,20 @@ def customizePom(pom, gradleProject) {
     generatedPom.project {
       name = "Spring Data REST"
       description = "Directly export Spring Data-managed PersistentEntities to the web."
-      url = 'http://github.com/SpringSource/spring-data-rest'
+      url = 'https://github.com/SpringSource/spring-data-rest'
       organization {
         name = 'SpringSource'
-        url = 'http://www.springsource.org/spring-data/rest'
+        url = 'https://www.springsource.org/spring-data/rest'
       }
       licenses {
         license {
           name 'The Apache Software License, Version 2.0'
-          url 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+          url 'https://www.apache.org/licenses/LICENSE-2.0.txt'
           distribution 'repo'
         }
       }
       scm {
-        url = 'http://github.com/SpringSource/spring-data-rest'
+        url = 'https://github.com/SpringSource/spring-data-rest'
         connection = 'scm:git:git://github.com/SpringSource/spring-data-rest'
         developerConnection = 'scm:git:git://github.com/SpringSource/spring-data-rest'
       }


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* http://m2.neo4j.org/releases (404) migrated to:  
  https://m2.neo4j.org/releases ([https](https://m2.neo4j.org/releases) result 404).

## Fixed Success 
These URLs were fixed successfully.

* http://www.apache.org/licenses/LICENSE-2.0.txt migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0.txt ([https](https://www.apache.org/licenses/LICENSE-2.0.txt) result 200).
* http://github.com/SpringSource/spring-data-rest migrated to:  
  https://github.com/SpringSource/spring-data-rest ([https](https://github.com/SpringSource/spring-data-rest) result 301).
* http://repo.springsource.org/libs-milestone migrated to:  
  https://repo.springsource.org/libs-milestone ([https](https://repo.springsource.org/libs-milestone) result 301).
* http://www.springsource.org/spring-data/rest migrated to:  
  https://www.springsource.org/spring-data/rest ([https](https://www.springsource.org/spring-data/rest) result 301).